### PR TITLE
chore: update namespace of links

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ This is a Bats test-suite that validates if a tldr-pages client is compatible wi
 
 | Client | Compliance |
 |---|---|
-| [tealdeer](https://github.com/dbrgn/tealdeer) | ![tldr-pages compliance level for tealdeer](https://SethFalco.github.io/tldr-pages-test-harness/tealdeer.png) |
-| [tldr-c-client](https://github.com/tldr-pages/tldr-c-client) | ![tldr-pages compliance level for tldr-c-client](https://SethFalco.github.io/tldr-pages-test-harness/tldr-c-client.png) |
-| [tldr-node-client](https://github.com/tldr-pages/tldr-node-client) | ![tldr-pages compliance level for tldr-node-client](https://SethFalco.github.io/tldr-pages-test-harness/tldr-node-client.png) |
-| [tldr-python-client](https://github.com/tldr-pages/tldr-python-client) | ![tldr-pages compliance level for tldr-python-client](https://SethFalco.github.io/tldr-pages-test-harness/tldr-python-client.png) |
-| [tlrc](https://github.com/tldr-pages/tlrc) | ![tldr-pages compliance level for tlrc](https://SethFalco.github.io/tldr-pages-test-harness/tlrc.png) |
+| [tealdeer](https://github.com/dbrgn/tealdeer) | ![tldr-pages compliance level for tealdeer](https://tldr-pages.github.io/tldr-pages-test-harness/tealdeer.png) |
+| [tldr-c-client](https://github.com/tldr-pages/tldr-c-client) | ![tldr-pages compliance level for tldr-c-client](https://tldr-pages.github.io/tldr-pages-test-harness/tldr-c-client.png) |
+| [tldr-node-client](https://github.com/tldr-pages/tldr-node-client) | ![tldr-pages compliance level for tldr-node-client](https://tldr-pages.github.io/tldr-pages-test-harness/tldr-node-client.png) |
+| [tldr-python-client](https://github.com/tldr-pages/tldr-python-client) | ![tldr-pages compliance level for tldr-python-client](https://tldr-pages.github.io/tldr-pages-test-harness/tldr-python-client.png) |
+| [tlrc](https://github.com/tldr-pages/tlrc) | ![tldr-pages compliance level for tlrc](https://tldr-pages.github.io/tldr-pages-test-harness/tlrc.png) |
 
 ## Usage
 


### PR DESCRIPTION
Update all links from my personal namespace to the tldr-pages namespace.

For now, I have it set, so compliance testing is run manually via worker dispatch. So, once merged we'll want to execute the action to generate the badges.

We can tidy up the workflow later, but I want to avoid wasting build minutes while this is still a WIP.