### PR TITLE
chore: add make command for docker-validate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,15 +12,35 @@ validate-level-2:
 validate-level-3:
 	@PATH_TO_TLDR_CLIENT="$(PATH_TO_TLDR_CLIENT)" ./tldr.bats
 
+.PHONY: docker-validate
+docker-validate: is-client-defined
+	docker build -t tldr-test:$$CLIENT -f dockerfiles/$$CLIENT/Dockerfile .
+	docker run -it tldr-test:$$CLIENT make validate
+
+.PHONY: docker-validate-level-2
+docker-validate-level-2: is-client-defined
+	docker build -t tldr-test:$$CLIENT -f dockerfiles/$$CLIENT/Dockerfile .
+	docker run -it tldr-test:$$CLIENT make validate-level-2
+
+.PHONY: docker-validate-level-3
+docker-validate-level-3: is-client-defined
+	docker build -t tldr-test:$$CLIENT -f dockerfiles/$$CLIENT/Dockerfile .
+	docker run -it tldr-test:$$CLIENT make validate-level-3
+
 test-clients:
-	mkdir /tmp/dist
-	for DIR in dockerfiles/*; \
+	@mkdir -p /tmp/dist
+	@for DIR in dockerfiles/*; \
 	do \
 		CLIENT=$$(basename $${DIR}); \
-		docker build -t tldr-test:$${CLIENT} -f dockerfiles/$${CLIENT}/Dockerfile .; \
-		if docker run tldr-test:$${CLIENT} make validate; then \
+		if CLIENT=$$CLIENT make docker-validate; then \
 			cp assets/pass.png /tmp/dist/$${CLIENT}.png; \
 		else \
 			cp assets/fail.png /tmp/dist/$${CLIENT}.png; \
 		fi; \
 	done;
+
+is-client-defined:
+ifndef CLIENT
+	@echo "CLIENT environment variable must be set to the name of a tldr-pages client";
+	@exit 1;
+endif

--- a/README.md
+++ b/README.md
@@ -32,13 +32,25 @@ You can run the `validate` task to test the `tldr` command found on your path:
 make validate
 ```
 
-Alternatively, you can test any arbitrary binary by specifying the `PATH_TO_TLDR_CLIENT` environment variable before hand:
+Alternatively, you can test any arbitrary binary by specifying the `PATH_TO_TLDR_CLIENT` environment variable:
 
 ```sh
 PATH_TO_TLDR_CLIENT={{path/to/binary}} make validate
 ```
 
 There are also the `validate-level-2` and `validate-level-3` tasks to check if clients adhere to optional parts of the spec.
+
+### Docker
+
+You can execute the tests for a predefined tldr-pages client even if you don't have it installed, so long as the Dockerfile is available for the client.
+
+Check the contents of the `dockerfiles/` directory, and run the `CLIENT={{client}} docker-validate` command, populating the `CLIENT` environment variable with the client to test. For example:
+
+```sh
+CLIENT=tldr-c-client make docker-validate
+```
+
+You can also run `docker-validate-level-2` or `docker-validate-level-3` to check optional parts of the spec.
 
 ## Dependencies
 


### PR DESCRIPTION
This makes it easier to run the tests for a particular client without needing to install the client. Instead, it builds and runs the Dockerfile for the respective tldr-pages client.

For example:

```sh
CLIENT=tealdeer make docker-validate
```

```
docker build -t tldr-test:$CLIENT -f dockerfiles/$CLIENT/Dockerfile .
[+] Building 0.7s (9/9) FINISHED                                                                                                           docker:default
 => [internal] load build definition from Dockerfile                                                                                                 0.0s
 => => transferring dockerfile: 322B                                                                                                                 0.0s
 => [internal] load metadata for docker.io/library/rust:bookworm                                                                                     0.7s
 => [internal] load .dockerignore                                                                                                                    0.0s
 => => transferring context: 75B                                                                                                                     0.0s
 => [1/4] FROM docker.io/library/rust:bookworm@sha256:a71cd88f9dd32fbdfa67c935f55165ddd89b7166e95de6c053c9bf33dd7381d5                               0.0s
 => [internal] load build context                                                                                                                    0.0s
 => => transferring context: 1.46kB                                                                                                                  0.0s
 => CACHED [2/4] RUN git clone https://github.com/bats-core/bats-core.git /tmp/bats-core &&     /tmp/bats-core/install.sh /usr/local &&     cargo i  0.0s
 => CACHED [3/4] WORKDIR /home/tldr                                                                                                                  0.0s
 => CACHED [4/4] COPY Makefile tldr.bats /home/tldr/                                                                                                 0.0s
 => exporting to image                                                                                                                               0.0s
 => => exporting layers                                                                                                                              0.0s
 => => writing image sha256:9b9af90af610a67d5e2c6723b8e6be8dda1d892974c362828f840bd554a1e1cb                                                         0.0s
 => => naming to docker.io/library/tldr-test:tealdeer                                                                                                0.0s
docker run -it tldr-test:$CLIENT make validate
tldr.bats
 ✓ REQUIRED: show tldr-page for tldr
 ✓ REQUIRED: show tldr-page for TLDR (must be treated as lowercase)
 ✓ REQUIRED: show tldr-page for git-switch (hyphenated page names)
 ✓ REQUIRED: show tldr-page for git switch (hyphen is implied and must be inserted transparently)
 ✓ REQUIRED: non-zero exit status for page that does not exist
 ✓ REQUIRED: non-zero exit status when page that does exist is not first argument
 ✓ REQUIRED: show client version with --version
 ✓ REQUIRED: show client version with -v (version shorthand)
 ✓ REQUIRED: show platform specific version of page with --platform
 ✓ REQUIRED: show platform specific version of page with -p (platform shorthand)
 ✓ REQUIRED: non-zero exit status with -p (platform shorthand) should error without value
 ✓ REQUIRED: non-zero exit status with --platform (platform) should error without value
 ✓ REQUIRED: if list argument supported, output shows one page per line (succeeds if not supported)
 ✓ REQUIRED: if LANG and LANGUAGE envvars are set to a supported language, output must use that language
 ✓ REQUIRED: if LANG and LANGUAGE envvars are not set, output must be in English

15 tests, 0 failures
```